### PR TITLE
Add #getValidationErrors

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -20,6 +20,16 @@ module.exports = (mongoose, _) ->
       else
         cb(err, true)
 
+  mongoose.Model::getValidationErrors = (cb) ->
+    try
+      @sync.validate()
+      cb(null, false)
+    catch ValidationError
+      messages = {}
+      for key, {type} of @errors
+        messages[key] = type
+      cb(null, messages)
+
   # records the previous document in @previousDoc
   recordPreviousDoc = ->
     try

--- a/test/mongoose_extensions.test.coffee
+++ b/test/mongoose_extensions.test.coffee
@@ -256,3 +256,31 @@ describe '#validateAndSave', ->
 
     it 'throws through', ->
       expect(-> model.sync.validateAndSave()).to.throw Error
+
+describe '#getValidationErrors', ->
+
+  describe 'a model with a required field', ->
+    model = null
+
+    before ->
+      schema = new mongoose.Schema
+        field: {type: String, required: true}
+      , strict: true
+      Model = mongoose.model('RequiredFieldTestModel', schema)
+
+    describe 'required field is present', ->
+      beforeEach ->
+        Model.sync.remove()
+        model = new Model field: 'foo'
+
+      it 'returns false', ->
+        expect(model.sync.getValidationErrors()).to.be.false
+
+    describe 'required field is missing', ->
+      beforeEach ->
+        Model.sync.remove()
+        model = new Model()
+
+      it 'returns an error hash', ->
+        expect(model.sync.getValidationErrors()).to.deep.equal {field: 'required'}
+


### PR DESCRIPTION
Allows you to ask whether a model is valid without having to save it. Convenient for validating form input pre-submit.
