### PR TITLE
Updating support to mongoose 4.x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,285 @@
+{
+  "name": "mongoose-extensions",
+  "version": "3.0.0",
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.0",
+      "from": "assertion-error@1.0.0",
+      "resolved": "https://npm.goodeggs.com/assertion-error/-/assertion-error-1.0.0.tgz"
+    },
+    "async": {
+      "version": "1.5.2",
+      "from": "async@1.5.2",
+      "resolved": "https://npm.goodeggs.com/async/-/async-1.5.2.tgz"
+    },
+    "bignumber.js": {
+      "version": "2.4.0",
+      "from": "bignumber.js@>=2.0.3 <3.0.0",
+      "resolved": "https://npm.goodeggs.com/bignumber.js/-/bignumber.js-2.4.0.tgz"
+    },
+    "bluebird": {
+      "version": "3.3.5",
+      "from": "bluebird@>=3.3.0 <3.4.0",
+      "resolved": "https://npm.goodeggs.com/bluebird/-/bluebird-3.3.5.tgz"
+    },
+    "bson": {
+      "version": "0.4.23",
+      "from": "bson@>=0.4.23 <0.5.0",
+      "resolved": "https://npm.goodeggs.com/bson/-/bson-0.4.23.tgz"
+    },
+    "commander": {
+      "version": "2.3.0",
+      "from": "commander@2.3.0",
+      "resolved": "https://npm.goodeggs.com/commander/-/commander-2.3.0.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://npm.goodeggs.com/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "from": "debug@2.2.0",
+      "resolved": "https://npm.goodeggs.com/debug/-/debug-2.2.0.tgz"
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "from": "deep-eql@0.1.3",
+      "resolved": "https://npm.goodeggs.com/deep-eql/-/deep-eql-0.1.3.tgz"
+    },
+    "diff": {
+      "version": "1.4.0",
+      "from": "diff@1.4.0",
+      "resolved": "https://npm.goodeggs.com/diff/-/diff-1.4.0.tgz"
+    },
+    "es6-promise": {
+      "version": "3.0.2",
+      "from": "es6-promise@3.0.2",
+      "resolved": "https://npm.goodeggs.com/es6-promise/-/es6-promise-3.0.2.tgz"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "from": "escape-string-regexp@1.0.2",
+      "resolved": "https://npm.goodeggs.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+    },
+    "fibers": {
+      "version": "1.0.13",
+      "from": "fibers@>=0.6.7",
+      "resolved": "https://npm.goodeggs.com/fibers/-/fibers-1.0.13.tgz"
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "from": "formatio@1.1.1",
+      "resolved": "https://npm.goodeggs.com/formatio/-/formatio-1.1.1.tgz"
+    },
+    "glob": {
+      "version": "3.2.11",
+      "from": "glob@3.2.11",
+      "resolved": "https://npm.goodeggs.com/glob/-/glob-3.2.11.tgz"
+    },
+    "growl": {
+      "version": "1.9.2",
+      "from": "growl@1.9.2",
+      "resolved": "https://npm.goodeggs.com/growl/-/growl-1.9.2.tgz"
+    },
+    "hooks-fixed": {
+      "version": "1.1.0",
+      "from": "hooks-fixed@1.1.0",
+      "resolved": "https://npm.goodeggs.com/hooks-fixed/-/hooks-fixed-1.1.0.tgz"
+    },
+    "inflect": {
+      "version": "0.3.0",
+      "from": "inflect@>=0.3.0 <0.4.0",
+      "resolved": "https://npm.goodeggs.com/inflect/-/inflect-0.3.0.tgz"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@2.0.1",
+      "resolved": "https://npm.goodeggs.com/inherits/-/inherits-2.0.1.tgz"
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "from": "isarray@0.0.1",
+      "resolved": "https://npm.goodeggs.com/isarray/-/isarray-0.0.1.tgz"
+    },
+    "jade": {
+      "version": "0.26.3",
+      "from": "jade@0.26.3",
+      "resolved": "https://npm.goodeggs.com/jade/-/jade-0.26.3.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "from": "commander@0.6.1",
+          "resolved": "https://npm.goodeggs.com/commander/-/commander-0.6.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "from": "mkdirp@0.3.0",
+          "resolved": "https://npm.goodeggs.com/mkdirp/-/mkdirp-0.3.0.tgz"
+        }
+      }
+    },
+    "kareem": {
+      "version": "1.1.3",
+      "from": "kareem@1.1.3",
+      "resolved": "https://npm.goodeggs.com/kareem/-/kareem-1.1.3.tgz"
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "from": "lolex@1.3.2",
+      "resolved": "https://npm.goodeggs.com/lolex/-/lolex-1.3.2.tgz"
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://npm.goodeggs.com/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "from": "minimatch@>=0.3.0 <0.4.0",
+      "resolved": "https://npm.goodeggs.com/minimatch/-/minimatch-0.3.0.tgz"
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "from": "minimist@0.0.8",
+      "resolved": "https://npm.goodeggs.com/minimist/-/minimist-0.0.8.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@0.5.1",
+      "resolved": "https://npm.goodeggs.com/mkdirp/-/mkdirp-0.5.1.tgz"
+    },
+    "mongodb": {
+      "version": "2.1.18",
+      "from": "mongodb@2.1.18",
+      "resolved": "https://npm.goodeggs.com/mongodb/-/mongodb-2.1.18.tgz"
+    },
+    "mongodb-core": {
+      "version": "1.3.18",
+      "from": "mongodb-core@1.3.18",
+      "resolved": "https://npm.goodeggs.com/mongodb-core/-/mongodb-core-1.3.18.tgz"
+    },
+    "mongoose-querystream-worker": {
+      "version": "3.0.0",
+      "from": "mongoose-querystream-worker@>=3.0.0 <4.0.0",
+      "resolved": "https://npm.goodeggs.com/mongoose-querystream-worker/-/mongoose-querystream-worker-3.0.0.tgz"
+    },
+    "mpath": {
+      "version": "0.2.1",
+      "from": "mpath@0.2.1",
+      "resolved": "https://npm.goodeggs.com/mpath/-/mpath-0.2.1.tgz"
+    },
+    "mpromise": {
+      "version": "0.5.5",
+      "from": "mpromise@0.5.5",
+      "resolved": "https://npm.goodeggs.com/mpromise/-/mpromise-0.5.5.tgz"
+    },
+    "mquery": {
+      "version": "1.11.0",
+      "from": "mquery@1.11.0",
+      "resolved": "https://npm.goodeggs.com/mquery/-/mquery-1.11.0.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@2.10.2",
+          "resolved": "https://npm.goodeggs.com/bluebird/-/bluebird-2.10.2.tgz"
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "from": "sliced@0.0.5",
+          "resolved": "https://npm.goodeggs.com/sliced/-/sliced-0.0.5.tgz"
+        }
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://npm.goodeggs.com/ms/-/ms-0.7.1.tgz"
+    },
+    "muri": {
+      "version": "1.1.0",
+      "from": "muri@1.1.0",
+      "resolved": "https://npm.goodeggs.com/muri/-/muri-1.1.0.tgz"
+    },
+    "q": {
+      "version": "1.4.1",
+      "from": "q@>=1.1.2 <2.0.0",
+      "resolved": "https://npm.goodeggs.com/q/-/q-1.4.1.tgz"
+    },
+    "readable-stream": {
+      "version": "1.0.31",
+      "from": "readable-stream@1.0.31",
+      "resolved": "https://npm.goodeggs.com/readable-stream/-/readable-stream-1.0.31.tgz"
+    },
+    "regexp-clone": {
+      "version": "0.0.1",
+      "from": "regexp-clone@0.0.1",
+      "resolved": "https://npm.goodeggs.com/regexp-clone/-/regexp-clone-0.0.1.tgz"
+    },
+    "require_optional": {
+      "version": "1.0.0",
+      "from": "require_optional@>=1.0.0 <1.1.0",
+      "resolved": "https://npm.goodeggs.com/require_optional/-/require_optional-1.0.0.tgz"
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "from": "resolve-from@>=2.0.0 <3.0.0",
+      "resolved": "https://npm.goodeggs.com/resolve-from/-/resolve-from-2.0.0.tgz"
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "from": "samsam@1.1.2",
+      "resolved": "https://npm.goodeggs.com/samsam/-/samsam-1.1.2.tgz"
+    },
+    "semver": {
+      "version": "5.3.0",
+      "from": "semver@>=5.1.0 <6.0.0",
+      "resolved": "https://npm.goodeggs.com/semver/-/semver-5.3.0.tgz"
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "https://npm.goodeggs.com/sigmund/-/sigmund-1.0.1.tgz"
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "from": "sliced@1.0.1",
+      "resolved": "https://npm.goodeggs.com/sliced/-/sliced-1.0.1.tgz"
+    },
+    "stream-worker": {
+      "version": "2.0.0",
+      "from": "stream-worker@>=2.0.0 <2.1.0",
+      "resolved": "https://npm.goodeggs.com/stream-worker/-/stream-worker-2.0.0.tgz"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "resolved": "https://npm.goodeggs.com/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "from": "supports-color@1.2.0",
+      "resolved": "https://npm.goodeggs.com/supports-color/-/supports-color-1.2.0.tgz"
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "from": "to-iso-string@0.0.2",
+      "resolved": "https://npm.goodeggs.com/to-iso-string/-/to-iso-string-0.0.2.tgz"
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "from": "type-detect@0.1.1",
+      "resolved": "https://npm.goodeggs.com/type-detect/-/type-detect-0.1.1.tgz"
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "from": "underscore@>=1.4.4 <2.0.0",
+      "resolved": "https://npm.goodeggs.com/underscore/-/underscore-1.8.3.tgz"
+    },
+    "util": {
+      "version": "0.10.3",
+      "from": "util@>=0.10.3 <1.0.0",
+      "resolved": "https://npm.goodeggs.com/util/-/util-0.10.3.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,16 +27,17 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "coffee-script": ">=1.8.x",
-    "fibrous": "^0.3.3",
+    "fibrous": "^0.4.0",
     "goodeggs-money": "^1.0.1",
-    "mocha-fibrous": "0.0.1",
-    "mongoose": "~3.6.17",
+    "mocha": "^2.5.3",
+    "mocha-fibers": "^1.1.1",
+    "mongoose": "^4.5.5",
     "sinon": "^1.12.2"
   },
   "scripts": {
     "compile": "coffee --bare --compile --output lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
-    "test": "mocha"
+    "test": "mocha --ui mocha-fibers"
   }
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -45,31 +45,6 @@ module.exports = (mongoose) ->
       cb(null) if cb?
     return result
 
-  mongoose.Query::paginate = (page = 1, pageSize = 10, cb) ->
-    complete = ([recordCount, records]) ->
-      records.page = page
-      records.pageSize = pageSize
-      records.pageCount = Math.ceil(recordCount / pageSize)
-      records.recordCount = recordCount
-      cb(null, records)
-
-    error = (err) ->
-      cb(err)
-
-    skip = (page - 1) * pageSize
-    [recordCount, records] = Q.all([
-      _.clone(@).exec('count')
-      @skip(skip).limit(pageSize).exec()
-    ]).then complete, error
-
-  mongoose.Types.DocumentArray::sequence = (ids) ->
-    ids = (id.toString() for id in ids)
-    sortKey = (model) ->
-      index = ids.indexOf(model.id.toString())
-      if index is -1 then ids.length else index
-
-    @sort (m1, m2) -> sortKey(m1) - sortKey(m2)
-
   mongoose.Document::paths = ->
     paths @toJSON()
 

--- a/src/mongoose_types.coffee
+++ b/src/mongoose_types.coffee
@@ -15,6 +15,8 @@ module.exports = (mongoose) ->
       if value instanceof Number or (typeof(value) is 'number') or (value?.toString() is Number(value))
         return Math.round(100 * value) / 100
 
+    @schemaName: 'Money'
+
   class Cents extends Types.Number
     cast: (value, doc, init) ->
       value = value.toNumber() if value.toNumber? # eg bignumber.js, goodeggs-money instances
@@ -26,11 +28,13 @@ module.exports = (mongoose) ->
       return null if value is ''
 
       if value instanceof Number or (typeof(value) is 'number')
-        throw new CastError('cents', value, @path) if value % 1 != 0 # not an int
+        throw new CastError('cents', value, @path) if value % 1 isnt 0 # not an int
         throw new CastError('cents', value, @path) if value < 0
         return value
 
       throw new CastError('cents', value, @path)
+
+    @schemaName: 'Cents'
 
   class Day extends Types.String
     cast: (value, doc, init) ->
@@ -39,6 +43,8 @@ module.exports = (mongoose) ->
 
       throw new CastError('day', value, @path) if !/\d{4}\-\d{2}-\d{2}/.test value
       super(value, doc, init)
+
+    @schemaName: 'Day'
 
   class TimeOfDay extends Types.String
     cast: (value, doc, init) ->
@@ -51,5 +57,7 @@ module.exports = (mongoose) ->
       throw new CastError('timeOfDay', value, @path) unless 0 <= Number(minutes) <= 59
 
       super(value, doc, init)
+
+    @schemaName: 'TimeOfDay'
 
   _(Types).extend({Money, Cents, Day, TimeOfDay})

--- a/test/mongoose_extensions.test.coffee
+++ b/test/mongoose_extensions.test.coffee
@@ -26,68 +26,6 @@ schema = new mongoose.Schema
 , strict: true
 ParentModel = mongoose.model('ParentTestModel', schema)
 
-describe 'mongoose query pagination', ->
-
-  beforeEach ->
-    Model.sync.remove()
-    Model.sync.create field: 'one'
-    Model.sync.create field: 'two'
-    Model.sync.create field: 'three'
-
-  describe '#paginate', ->
-
-    it 'returns the result augmented with pagination properties', ->
-      models = Model.find().sync.paginate 1, 2
-      expect(models.length).to.eql 2
-      expect(models[0] instanceof Model).to.be.true
-      expect(models[1] instanceof Model).to.be.true
-      expect(models.page).to.eql 1
-      expect(models.pageSize).to.eql 2
-      expect(models.recordCount).to.eql 3
-      expect(models.pageCount).to.eql 2
-
-    it 'respects the query', ->
-      models = Model.find().where('field', 'one').sync.paginate 1, 10
-      expect(models.length).to.eql 1
-      expect(models.recordCount).to.eql 1
-      expect(models[0].field).to.eql 'one'
-
-    it 'respects sort', ->
-      models = Model.find().sort('-field').sync.paginate 1, 10
-      expect(models.length).to.eql 3
-      expect(models.recordCount).to.eql 3
-      expect(models[0].field).to.eql 'two'
-      expect(models[1].field).to.eql 'three'
-      expect(models[2].field).to.eql 'one'
-
-describe 'DocumentArray', ->
-  parent = null
-  models = null
-
-  beforeEach ->
-    parent = ParentModel.sync.create models: [
-      Model.sync.create field: 'one'
-      Model.sync.create field: 'two'
-      Model.sync.create field: 'three'
-    ]
-    models = parent.models.slice()
-
-  describe '#sequence', ->
-    it 'updates array order', ->
-      models.reverse()
-
-      parent.models.sequence(_(models).pluck('id'))
-      parent.sync.save()
-
-      parent = ParentModel.sync.findById parent
-      expect(_(parent.models).pluck('id')).to.eql _(models).pluck('id')
-
-    it 'does not drop missing models', ->
-      parent.models.sequence([models[2].id])
-      parent.sync.save()
-      parent = ParentModel.sync.findById parent
-      expect(_(parent.models).pluck('id')).to.eql [models[2].id, models[0].id, models[1].id]
-
 describe 'mergeAndClearNulls', ->
   model = null
 

--- a/test/mongoose_types.test.coffee
+++ b/test/mongoose_types.test.coffee
@@ -2,7 +2,7 @@ require './setup'
 fibrous  = require 'fibrous'
 {expect} = require 'chai'
 
-{Schema} = mongoose = require 'mongoose'
+{Schema, Error} = mongoose = require 'mongoose'
 Cents = require 'goodeggs-money'
 
 mongooseTypes = require('../src/mongoose_types')(mongoose)
@@ -78,20 +78,10 @@ describe 'mongoose_types', ->
         expect(testObj.cents).to.eql 5
 
       it 'should throw if cents is not an int', fibrous ->
-        try
-          new TestObject(cents: 1.001).sync.save()
-        catch e
-          error = e
-
-        expect(error).to.have.property('message', 'Cast to cents failed for value "1.001" at path "cents"')
+        expect(-> new TestObject(cents: 1.001).sync.save()).to.throw Error.ValidationError
 
       it 'should throw if cents is a negative int', fibrous ->
-        try
-          new TestObject(cents: -1).sync.save()
-        catch e
-          error = e
-
-        expect(error).to.have.property('message', 'Cast to cents failed for value "-1" at path "cents"')
+        expect(-> new TestObject(cents: -1).sync.save()).to.throw Error.ValidationError
 
       it 'properly casts string', fibrous ->
         testObj = new TestObject(cents: '5')
@@ -130,7 +120,7 @@ describe 'mongoose_types', ->
 
       it 'throws for invalid values', fibrous ->
         testObj = new TestObject(day: '20130401')
-        expect(-> testObj.sync.save()).to.throw('Cast to day failed for value "20130401" at path "day"')
+        expect(-> testObj.sync.save()).to.throw Error.ValidationError
 
   describe 'TimeOfDay', ->
     describe 'cast', ->
@@ -154,12 +144,12 @@ describe 'mongoose_types', ->
 
       it 'throws for malformed values', fibrous ->
         testObj = new TestObject(timeOfDay: '13')
-        expect(-> testObj.sync.save()).to.throw('Cast to timeOfDay failed for value "13" at path "timeOfDay"')
+        expect(-> testObj.sync.save()).to.throw Error.ValidationError
 
       it 'throws for invalid hours', fibrous ->
         testObj = new TestObject(timeOfDay: '24:00')
-        expect(-> testObj.sync.save()).to.throw('Cast to timeOfDay failed for value "24:00" at path "timeOfDay"')
+        expect(-> testObj.sync.save()).to.throw Error.ValidationError
 
       it 'throws for invalid minutes', fibrous ->
         testObj = new TestObject(timeOfDay: '13:60')
-        expect(-> testObj.sync.save()).to.throw('Cast to timeOfDay failed for value "13:60" at path "timeOfDay"')
+        expect(-> testObj.sync.save()).to.throw Error.ValidationError

--- a/test/setup.coffee
+++ b/test/setup.coffee
@@ -1,6 +1,5 @@
+require 'mocha-fibers'
 require 'fibrous'
-require 'mocha-fibrous'
 
 mongoose = require 'mongoose'
-mongoose.connect('mongodb://localhost/test');
-
+mongoose.connect 'mongodb://localhost/test'


### PR DESCRIPTION
- Updates mongoose support to `4.X`
- Removes `Query#paginate`
- `DocumentArray#sequence`
- Uses `mocha-fibers` instead of deprecated `mocha-fibrous`
